### PR TITLE
Fix eksctl get cluster command

### DIFF
--- a/01-EKS-Create-Cluster-using-eksctl/01-02-Create-EKSCluster-and-NodeGroups/README.md
+++ b/01-EKS-Create-Cluster-using-eksctl/01-02-Create-EKSCluster-and-NodeGroups/README.md
@@ -13,24 +13,24 @@
 
 
 ## Step-01: Create EKS Cluster using eksctl
-- It will take 15 to 20 minutes to create the Cluster Control Plane 
+- It will take 15 to 20 minutes to create the Cluster Control Plane
 ```
 # Create Cluster
 eksctl create cluster --name=eksdemo1 \
                       --region=us-east-1 \
                       --zones=us-east-1a,us-east-1b \
-                      --without-nodegroup 
+                      --without-nodegroup
 
 # Get List of clusters
-eksctl get clusters                  
+eksctl get cluster
 ```
 
 
 ## Step-02: Create & Associate IAM OIDC Provider for our EKS Cluster
 - To enable and use AWS IAM roles for Kubernetes service accounts on our EKS cluster, we must create &  associate OIDC identity provider.
-- To do so using `eksctl` we can use the  below command. 
+- To do so using `eksctl` we can use the  below command.
 - Use latest eksctl version (as on today the latest version is `0.21.0`)
-```                   
+```
 # Template
 eksctl utils associate-iam-oidc-provider \
     --region region-code \
@@ -54,7 +54,7 @@ eksctl utils associate-iam-oidc-provider \
 ## Step-04: Create Node Group with additional Add-Ons in Public Subnets
 - These add-ons will create the respective IAM policies for us automatically within our Node Group role.
  ```
-# Create Public Node Group   
+# Create Public Node Group
 eksctl create nodegroup --cluster=eksdemo1 \
                         --region=us-east-1 \
                         --name=eksdemo1-ng-public1 \
@@ -70,7 +70,7 @@ eksctl create nodegroup --cluster=eksdemo1 \
                         --external-dns-access \
                         --full-ecr-access \
                         --appmesh-access \
-                        --alb-ingress-access 
+                        --alb-ingress-access
 ```
 
 ## Step-05: Verify Cluster & Nodes


### PR DESCRIPTION
It should be "eksctl get cluster" not clusters.

```
❯ eksctl get clsuters
Error: unknown resource type "clsuters"

Get resource(s)

Usage: eksctl get [flags]

Commands:
  eksctl get addon                           Get an Addon
  eksctl get cluster                         Get cluster(s)
  eksctl get fargateprofile                  Get Fargate profile(s)
  eksctl get iamidentitymapping              Get IAM identity mapping(s)
  eksctl get iamserviceaccount               Get iamserviceaccount(s)
  eksctl get identityprovider                Describe identity providers for cluster authentication and authorization
  eksctl get labels                          Get labels for managed nodegroup
  eksctl get nodegroup                       Get nodegroup(s)
```